### PR TITLE
docs(release): add documentation for semantic release

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -12,14 +12,12 @@ Credentials and admin access lie with that team. <!-- TODO: If you have question
 
 Concourse is used as CI system. There are two main types of tests and various release specific steps, all of which are defined in [pipeline.yml](pipeline.yml).
 
-* `unit-tests` and `unit-tests-pr` run a series of unit tests on the Ruby templating based configuration file generators and includes linters for all code and test code.
+* `unit-tests` and `unit-tests-pr` run a series of tests on the Ruby templating based configuration file generators as well Go unit and integration tests. They also include linters for all code and test code.
 
 
 ## Current State
 
-Currently, the PR validation uses the docker image `iacbox.common.repositories.cloud.sap/haproxy-boshrelease-testflight`. This is suboptimal as that image doesn't contain `libpcap-dev` but contains several `haproxy-boshrelease` specific packages instead.
-
-A decision still has to be made on whether to adjust the image to work for both `pcap-release` and `haproxy-boshrelease` or if a new image should be created and maintained for `pcap-release`. This will be done during implementation of acceptance tests and automatic release creation.
+Currently, the PR validation uses the docker image `cf-routing.common.repositories.cloud.sap/pcap-release-testflight`. 
 
 <!-- TODO: * `acceptance-tests` and `acceptance-tests-pr` runs a series of acceptance tests developed in Go.
   * `acceptance-tests-pr` is executed for each PR that is marked with the `run-ci` label, while

--- a/ci/README.md
+++ b/ci/README.md
@@ -118,3 +118,23 @@ Note that you can use the `dir` parameter in `run` to define the working directo
 ```
 
 Don't forget to remove separate pipelines that were created for testing.
+
+## Concourse Pipeline for Releases
+
+The releases of a `pcap-release` is done using [semantic-release](https://github.com/semantic-release/semantic-release).
+
+The next version is determined based on the last git tag and a series of commits, following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+The configuration for semantic-release is defined in [.releaserc](../.releaserc).
+
+The following markers in commits will lead to a new major release (all case-insensitive):
+* `BREAKING CHANGE`
+* `BREAKING-CHANGE`
+
+Otherwise, the [angular rules for semantic-release](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) apply.
+
+### Concourse Pipeline
+
+The Concourse pipeline has the following jobs for releases:
+* `rc` provides a semantic-release try run, which shows what would happen if you ran `shipit` now. It provides a preview of the version to be created and the full release note.
+* `shipit` uses semantic-release, following the rules defined above and creates a bosh-release with the appropriate next version, creates a release note based on conventional commits and publishes the release to GitHub.


### PR DESCRIPTION
Includes documentation for the semantic release configuration itself and the jobs in Concourse that can be used to issue semantic releases.