### PR TITLE
fix: request and verify client certificates if ca is configured

### DIFF
--- a/src/pcap/config.go
+++ b/src/pcap/config.go
@@ -102,6 +102,7 @@ func LoadTLSCredentials(certFile, keyFile string, caFile *string, peerCAFile *st
 			return nil, fmt.Errorf("load certificate authority file failed: %w", err)
 		}
 		tlsConf.ClientCAs = caPool
+		tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 
 	if peerCAFile != nil {


### PR DESCRIPTION
If one or more certificates are configured for client authentication we now automatically request and verify certificates from the client.