### PR TITLE
fix(ci): only trigger ci on approved PRs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -237,6 +237,7 @@ resources:
       repository: cloudfoundry/pcap-release
       base_branch: main
       labels: [run-ci]
+      required_review_approvals: 1
 
   - name: notify
     type: slack-notification


### PR DESCRIPTION
- CI can now only be triggered with both "run-ci" label and a fresh approval by one of the code owners
- approvals will be revoked on code changes
- pipeline already patched