### PR TITLE
Add dependabot to pcap-release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: /acceptance-tests
-  schedule:
-    interval: weekly
-    day: "monday"
-    time: "09:00"
-    timezone: "Europe/Berlin"
 - package-ecosystem: pip
   directory: /ci/scripts
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /acceptance-tests
+  schedule:
+    interval: weekly
+    day: "monday"
+    time: "09:00"
+    timezone: "Europe/Berlin"
+- package-ecosystem: pip
+  directory: /ci/scripts
+  schedule:
+    interval: weekly
+    day: "monday"
+    time: "09:00"
+    timezone: "Europe/Berlin"
+- package-ecosystem: gomod
+  directory: /src/pcap
+  schedule:
+    interval: weekly
+    day: "monday"
+    time: "09:00"
+    timezone: "Europe/Berlin"


### PR DESCRIPTION
Dependabot helps with keeping dependencies for acceptance tests, build scripts and the pcap source code.