### PR TITLE
Bump libpcap version to 1.10.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,3 +6,7 @@ libpcap-1.10.1.tgz:
   size: 935221
   object_id: 71073646-0c7a-4aba-5c05-19f5330adb7a
   sha: sha256:ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4
+pcap-api/libpcap-1.10.4.tar.gz:
+  size: 952153
+  object_id: 6376d4da-cd8d-4c0a-4f79-c13fffb0bf65
+  sha: sha256:ed19a0383fad72e3ad435fd239d7cd80d64916b87269550159d20e47160ebe5f

--- a/packages/pcap-api/packaging
+++ b/packages/pcap-api/packaging
@@ -19,7 +19,7 @@ export GOPATH=$BOSH_COMPILE_TARGET/gopath
 export GOCACHE=$BOSH_COMPILE_TARGET/gocache
 
 echo "Build libpcap"
-LIBPCAP_VERSION=1.10.1 # https://www.tcpdump.org/release/
+LIBPCAP_VERSION=1.10.4  # https://www.tcpdump.org/release/libpcap-1.10.4.tar.gz
 mkdir "${BOSH_COMPILE_TARGET}/libpcap"
 tar xzf libpcap-${LIBPCAP_VERSION}.tgz --strip-components 1 -C "${BOSH_COMPILE_TARGET}/libpcap"
 


### PR DESCRIPTION

Automatic bump from version 1.10.1 to version 1.10.4, downloaded from https://www.tcpdump.org/release/libpcap-1.10.4.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
