### PR TITLE
Add our convention to dependabot for commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     day: "monday"
     time: "09:00"
     timezone: "Europe/Berlin"
+  commit-message:
+    prefix: "ci"
+  labels:
+    - run-ci
 - package-ecosystem: gomod
   directory: /src/pcap
   schedule:
@@ -14,3 +18,7 @@ updates:
     day: "monday"
     time: "09:00"
     timezone: "Europe/Berlin"
+  commit-message:
+    prefix: "dep"
+  labels:
+    - run-ci


### PR DESCRIPTION
We use:
* `dep` for dependency updates in the resulting build
* `ci` for dependencies in the build infrastructure that don't directly have an impact no the build output