### PR TITLE
ci: display the currently bundle golang-release in the release note

### DIFF
--- a/ci/scripts/notes.sh
+++ b/ci/scripts/notes.sh
@@ -25,4 +25,10 @@ releases:
 \`\`\`
 EOF
 
+cat >> "${CONCOURSE_ROOT}/${RELEASE_ROOT}/notes.md" <<EOF
+
+### ✨ Built with Go $(cat "${CONCOURSE_ROOT}/${REPO_ROOT}/packages/golang-1-linux/version")
+
+EOF
+
 cat "${CONCOURSE_ROOT}/${RELEASE_ROOT}/notes.md"


### PR DESCRIPTION
related: #16 