### PR TITLE
fix(ci): move rc behind acceptance-tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -260,7 +260,7 @@ jobs:
     plan:
     - do:
       - in_parallel:
-          - { get: git,     passed: [unit-tests] }
+          - { get: git,     passed: [acceptance-tests] }
       - task: release-candidate
         config:
           platform: linux


### PR DESCRIPTION
found a small issue in the pipeline order. "rc" has to move behind "acceptance-tests" now. already fixed in live concourse.