### PR TITLE
Enforce commits are following our conventions via github actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.x'
+      - name: Install commitlint
+        run: npm install -g commitlint
+      - name: Validate PR commits with @commitlint/cli
+        run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,71 @@
+module.exports = {
+    rules: {
+        // rules are defined as [ severity (2=error), "always"|"never", argument? ]. See
+        // https://commitlint.js.org/#/reference-rules?id=rules
+
+        // log-commit-info is used for debugging. It outputs the dict passed to a plugin.
+        // 'log-commit-info': [2, 'always'],
+        // enforce that commits with a breaking change indicator ("!") must also contain an explanation of the breaking change.
+        'breaking-change-indicator': [2, 'always'],
+        // enforce that only the types below are allowed
+        'type-enum': [2, 'always',
+            [
+                'feat',
+                'fix',
+                'dep',
+                'ci',
+                'refactor',
+                'doc',
+                'test',
+            ]
+        ],
+        // enforce that a type is mandatory
+        'type-empty': [2, 'never'],
+        // enforce the maximum subject length (without type and scope)
+        'subject-max-length': [2, 'always', 75],
+        // enforce the maximum scope length
+        'scope-max-length': [2, 'always', 25],
+    },
+    parserPreset: {
+        parserOpts: {
+            // add matching groups for `!` before and after scope. Before scope is invalid, after scope is correct
+            // and enforces the "breaking-change" header (see below).
+            headerPattern: /^(\w*)(?:(!?)\(([\w\$\.\-\* ]*)\))?(!?)\: (.*)$/,
+            headerCorrespondence: ["type", "wrong_breaking", "scope", "breaking", "subject"],
+        },
+    },
+    plugins: [
+        {
+            rules: {
+                // log-commit-info is used for debugging. It outputs the dict passed to a plugin.
+                // 'log-commit-info': (input) => {
+                //     console.log(input)
+                //     return [true, "see above"]
+                // },
+                'breaking-change-indicator': ({wrong_breaking, breaking, scope, body, footer}) => {
+                    if (wrong_breaking) {
+                        return [
+                            false, "The breaking change indicator `!` can only be used right before `:`, e.g. `feat(scope)!:`."
+                        ]
+                    }
+
+                    const rxBreakingChange = /^breaking(\s|-)change: .+/img
+
+                    // The marker "breaking change:" is treated as footer and "note" by commitlint, and not considered part of the body.
+                    // When a breaking change indicator ("!") is there, we need to check body and footer to cover both variants (with and without "-").
+
+                    // `commitOk` indicates, if the commit passes the rules.
+                    const commitOk =
+                        !breaking // if there is no "!" in the commit, we don't enforce a footer
+                        || body?.match(rxBreakingChange) // if there is a "!", and a body exists, it must match the breaking change pattern
+                        || footer?.match(rxBreakingChange) // if there is a "!", and a footer exists, it must match the breaking change pattern
+
+                    return [
+                        commitOk,
+                        'For a breaking change (indicated with `!` after the type), the commit must mention a trailer `breaking-change:` or `breaking change:` (case in-sensitive)'
+                    ];
+                },
+            },
+        },
+    ],
+};


### PR DESCRIPTION
Adds a commitlint check job that ensures the following rules:

1. conventional commits
2. supported commit types: `feat`, `fix`, `dep`, `doc`, `ci`, `refactor`, `test`
3. Breaking changes can be indicated with a `!` before `:`, e.g. `feat!: new breaking feature`.  
   Breaking changes _must_ have a `breaking-change:` or `breaking change:` trailer. This is case in-sensitive.

The commitlint configuration ensures those settings. The GitHub Actions job executes them and fails the PR validation if any of the commits in a PR are not compliant. Those can then be amended as needed by the PR author.