### PR TITLE
fix(ci): use lts version of nodejs to fix docker-for-mac build

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,14 +3,15 @@ FROM bosh/docker-cpi:main
 
 ARG GINKGO_VERSION=latest
 ARG GOLANGCILINT_VERSION=latest
-RUN apt-get update && apt-get install -y libpcap-dev python3-pip && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && \
-    apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
-
 # Set bosh env at login
 RUN echo "source /tmp/local-bosh/director/env" >> /root/.bashrc
 
+# Install apt libs
+RUN apt-get update && apt-get install -y libpcap-dev python3-pip && rm -rf /var/lib/apt/lists/*
+
+# Install semantic-release and node lts
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && \
+    apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
 RUN npm install -g semantic-release && \
     npm install -g @semantic-release/exec
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,7 @@ ARG GINKGO_VERSION=latest
 ARG GOLANGCILINT_VERSION=latest
 RUN apt-get update && apt-get install -y libpcap-dev python3-pip && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && \
     apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
 
 # Set bosh env at login


### PR DESCRIPTION
Fixes hanging `npm install` command.