### PR TITLE
fix: Make sure pcap is deployable via manifest and ops files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,32 +61,41 @@ For tcpdumps of CF app containers, pcap-release provides a plugin to the CF Clou
 The release provides two files to integrate with an
 existing [cf-deployment](https://github.com/cloudfoundry/cf-deployment):
 
-* `manifests/ops-files/add-pcap-agent.yml` This provides a shared CA between pcap-agent and pcap-api. It also adds the pcap-agent job to all diego cells.
-* `manifests/pcap-api.yml` This is an example BOSH manifest to deploy the pcap-api
+* `manifests/ops-files/add-pcap-agent.yml` This adds the PCAP agent as an addon to any BOSH deployment.
+* `manifests/pcap-api.yml` This is an example BOSH manifest to deploy the pcap-api and agent.
 
-### Step 1 - Add pcap-agent to cf-deployment
+### Step 1 - Prepare vars.yml
+```bash
+cp manifests/vars-template.yml manifests/vars.yml
+vim manifests/vars.yml (adjust as needed)
+```
+
+### Step 2 - Deploy pcap-api
 
 ```bash
-bosh interpolate -o manifests/ops-files/add-pcap-agent.yml cf-deployment.yml > cf-deployment-pcap.yml
+bosh -d pcap deploy -l manifests/vars.yml manifests/pcap-api.yml
+```
+
+### Step 3 - Add pcap-agent to cf-deployment
+
+```bash
+bosh interpolate -o manifests/ops-files/add-pcap-agent.yml -l manifests/vars.yml cf-deployment.yml > cf-deployment-pcap.yml
 bosh -d cf deploy cf-deployment-pcap.yml
 ```
 
 This assumes your BOSH deployment name of cf-deployment is called `cf`
 
-### Step 2 - Deploy pcap-api
+
+### Step 4 - Install CF CLI plugin
+
+tbd
+
+### Step 5 - Install BOSH CLI
 
 ```bash
-cp manifests/vars-template.yml manifests/vars.yml
-vim manifests/vars.yml (adjust as needed)
-bosh -d pcap deploy -l manifests/vars.yml manifests/pcap-api.yml
-```
-
-### Step 3 - Install CF CLI plugin
-
-```bash
-wget https://pcap.cf.cfapp.com/cli/pcap-cli-[linux|mac]-amd64 (adjust URL as needed) -O pcap-cli
-cf install-plugin pcap-cli
-cf pcap ...
+bosh -d pcap scp <bosh instance of pcap api>:/var/vcap/packages/pcap-api/bin/cli/build/pcap-bosh-cli-linux-amd64
+mv pcap-bosh-cli-linux-amd64 /usr/local/bin/pcap-bosh
+pcap-bosh ...
 ```
 
 ## Development Deployment for BOSH

--- a/manifests/ops-files/add-pcap-agent.yml
+++ b/manifests/ops-files/add-pcap-agent.yml
@@ -3,36 +3,12 @@
   path: /releases/name=pcap?
   value:
     name: pcap
-    version: 0+dev.7
-    url: https://github.com/cloudfoundry/pcap-release/releases/download/v0.0.1/pcap-0.0.1.tgz
-    sha1: a1655c1992b911fef3ad0b46c5abb8a0217ef0a2
+    version: "1.1.0"
+    url: "https://github.com/cloudfoundry/pcap-release/releases/download/v1.1.0/pcap-v1.1.0.tgz"
+    sha1: "50444b75da6b6376e8218400145df46d17c4c877"
 
 - type: replace
-  path: /variables/name=pcap_ca?
-  value:
-    name: pcap_ca
-    type: certificate
-    options:
-      common_name: pcap_ca
-      is_ca: true
-
-- type: replace
-  path: /variables/name=pcap_agent_mtls?
-  value:
-    name: pcap_agent_mtls
-    type: certificate
-    update_mode: converge
-    options:
-      ca: /bosh/pcap/pcap.ca
-      common_name: pcap_agent_mtls
-      alternative_names:
-        - pcap-agent.service.cf.internal
-      extended_key_usage:
-        - client_auth
-        - server_auth
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=pcap-agent?
+  path: /addons/name=pcap-agent?/jobs/-
   value:
     name: pcap-agent
     release: pcap
@@ -47,6 +23,6 @@
         listen:
           port: 9494
           tls:
-            certificate: ((pcap_agent_mtls.certificate))
-            private_key: ((pcap_agent_mtls.private_key))
-            ca: ((/bosh/pcap/pcap_ca.ca))
+            certificate: ((pcap_agent.certificate))
+            private_key: ((pcap_agent.private_key))
+            client_cas: ((pcap_agent.client_cas))

--- a/manifests/pcap-api.yml
+++ b/manifests/pcap-api.yml
@@ -7,6 +7,9 @@ addons:
       - name: bpm
         release: bpm
   - name: bosh-dns-aliases
+    include:
+      instance_groups:
+        - pcap-api
     jobs:
       - name: bosh-dns-aliases
         release: bosh-dns-aliases
@@ -39,7 +42,7 @@ instance_groups:
         release: pcap
         properties:
           pcap-api:
-            log_level: info
+            log_level: debug
             buffer:
               size: 1000
               upper_limit: 995
@@ -48,19 +51,23 @@ instance_groups:
             listen:
               port: 8080
               tls:
-                enabled: false
+                enabled: true
+                client_cas: ((pcap_api.client_cas))
+                certificate: ((pcap_api.certificate))
+                private_key: ((pcap_api.private_key))
             bosh:
               director_url: ((pcap_api.bosh_director_api))
               token_scope: bosh.admin
               agent_port: 9494
               tls:
-                common_name: bosh.service.cf.internal
+                enabled: true
+                common_name: ((pcap_api.bosh_director_name))
                 skip_verify: false
-                ca: ((/bootstrap-bosh/bosh/default_ca.ca))
+                ca: ((pcap_api.bosh_director_ca))
             agents_mtls:
               common_name: pcap-agent.service.cf.internal
               skip_verify: false
-              certificate: ((pcap_api_mtls.certificate))
+              certificate: ((pcap_api_mtls.certificate))((pcap_agent_mtls.ca))
               private_key: ((pcap_api_mtls.private_key))
               ca: ((pcap_agent_mtls.ca))
       - name: route_registrar
@@ -73,8 +80,10 @@ instance_groups:
           route_registrar:
             routes:
               - name: pcap-api-public-endpoint
+                protocol: http2
                 registration_interval: 20s
-                port: 8080
+                server_cert_domain_san: platform-services.service.cf.internal
+                tls_port: 8080
                 uris:
                   - ((route_registrar.public_route))
           nats:
@@ -117,15 +126,16 @@ releases:
     version: 1.1.21
     sha1: e8abe19ec186962828de843f8f281cddb6141904
   - name: pcap
-    version: 0+dev.1682596802
+    version: "1.1.0"
+    url: "https://github.com/cloudfoundry/pcap-release/releases/download/v1.1.0/pcap-v1.1.0.tgz"
+    sha1: "50444b75da6b6376e8218400145df46d17c4c877"
   - name: bosh-dns-aliases
     version: 0.0.4
     url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
     sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
   - name: routing
-    url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.259.0
-    version: 0.259.0
-
+    url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.268.0
+    version: 0.268.0
 variables:
   - name: pcap_ca
     type: certificate
@@ -153,12 +163,3 @@ variables:
       extended_key_usage:
         - client_auth
         - server_auth
-  - name: pcap_api_bosh_mtls
-    type: certificate
-    options:
-      ca: /bootstrap/bosh/default_ca
-      common_name: pcap_api_bosh_mtls
-      alternative_names:
-        - pcap-api.service.cf.internal
-      extended_key_usage:
-        - client_auth

--- a/manifests/vars-template.yml
+++ b/manifests/vars-template.yml
@@ -4,11 +4,18 @@ pcap_api:
   vm_type: default
   networks: [{name: default}]
   cf_api: https://api.cf.cfapp.com
-  ca_path: /cf/pcap_ca
-  bosh_director_ca: /bosh/default_ca.ca
-  bosh_director_api: https://192.168.1.11:25555
+  bosh_director_ca: ((/bosh/default_ca.ca))
+  bosh_director_api: https://bosh.cf.internal:25555
+  bosh_director_name: bosh.cf.internal
+  client_cas: ((/bosh/cf/gorouter_backend_tls.ca))
+  certificate: ((/bosh/cf/platform_services_cert.certificate))
+  private_key: ((/bosh/cf/platform_services_cert.private_key))
 route_registrar:
   public_route: pcap.cf.cfapp.com
 nats:
-  client_cert: /cf/nats_client_cert.certificate
-  client_key: /cf/nats_client_cert.private_key
+  client_cert: ((/bosh/cf/nats_client_cert.certificate))
+  client_key: ((/bosh/cf/nats_client_cert.private_key))
+pcap_agent:
+  client_cas: ((/bosh/pcap/pcap_ca.ca))
+  certificate: ((/bosh/pcap/pcap_agent_mtls.certificate))((/bosh/pcap/pcap_agent_mtls.ca))
+  private_key: ((/bosh/pcap/pcap_agent_mtls.private_key))


### PR DESCRIPTION
- make pcap-agent an addon
- remove unused cert / ca variables from pcap-agent ops file (we are using the ca from pcap-api.yml)
- backport fixes to pcap-api.yml
- remove unused pcap_api_bosh_mtls cert
- update vars-template so that it actually works
- update README.me to reflect the current state