### PR TITLE
fix: allow agent to shut down right away

### DIFF
--- a/src/pcap/agent.go
+++ b/src/pcap/agent.go
@@ -143,6 +143,13 @@ func (a *Agent) Capture(stream Agent_CaptureServer) (err error) {
 		<-ctx.Done()
 	}
 
+	// To release the readPackets routine we have to close the handle,
+	// otherwise we are forced to wait until a new packet is captured before
+	// observing that the context has been cancelled. This is because the call
+	// to read a packet blocks until either a packet is read or the handle is
+	// closed.
+	handle.Close()
+
 	err = context.Cause(ctx)
 	// Cancelling the context with nil causes context.Cancelled to be set
 	// which is a non-error in our case.


### PR DESCRIPTION
To be able to notice that the context has been cancelled we rely on at least one more packet being read. In practice this should be fine but especially during testing it can cause the agent to hang because no more data is captured. This commit closes the pcap handle early to unblock the read call and allow the agent to shut down right away.