### PR TITLE
ci: Update golang-release git repo and branch

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -377,8 +377,8 @@ resources:
   - name: golang-release
     type: git
     source:
-      uri: https://github.com/bosh-packages/golang-release.git
-      branch: master
+      uri: https://github.com/cloudfoundry/bosh-package-golang-release
+      branch: main
       password: ((github.access_token))
 
   - name: git-pull-requests


### PR DESCRIPTION
Upstream renamed the repo and changed from `master` to `main`.

See: https://github.com/cloudfoundry/bosh-package-golang-release/commit/79a1d8acd7e2e3ff4bfa1a35a316e29a438cb0d2