### PR TITLE
refactor(api): Make maxConcurrentCaptures int32 to avoid cast.

### DIFF
--- a/src/pcap/api.go
+++ b/src/pcap/api.go
@@ -28,14 +28,14 @@ type API struct {
 	// id of the instance where the api is located.
 	id string
 
-	maxConcurrentCaptures uint
+	maxConcurrentCaptures int32
 	concurrentStreams     atomic.Int32
 	tlsCredentials        credentials.TransportCredentials
 
 	UnimplementedAPIServer
 }
 
-func NewAPI(bufConf BufferConf, clientTLS *ClientTLS, id string, maxConcurrentCaptures uint) (*API, error) {
+func NewAPI(bufConf BufferConf, clientTLS *ClientTLS, id string, maxConcurrentCaptures int32) (*API, error) {
 	clientTLSCreds := insecure.NewCredentials()
 	if clientTLS != nil {
 		clientTLSConf, err := clientTLS.Config()
@@ -182,7 +182,7 @@ func (api *API) Capture(stream API_CaptureServer) (err error) {
 
 	defer api.concurrentStreams.Add(-1)
 
-	if currentStreams > int32(api.maxConcurrentCaptures) {
+	if currentStreams > api.maxConcurrentCaptures {
 		vcapID, ok := ctx.Value(HeaderVcapID).(string)
 		if !ok {
 			return errorf(codes.ResourceExhausted, "failed starting capture: %w", errTooManyCaptures)

--- a/src/pcap/cmd/pcap-api/config.go
+++ b/src/pcap/cmd/pcap-api/config.go
@@ -30,7 +30,7 @@ var DefaultAPIConfig = APIConfig{
 type APIConfig struct {
 	pcap.NodeConfig    `yaml:"-,inline"`
 	AgentsMTLS         *pcap.ClientTLS `yaml:"agents_mtls" validate:"omitempty"`
-	ConcurrentCaptures uint            `yaml:"concurrent_captures"`
+	ConcurrentCaptures int32           `yaml:"concurrent_captures"`
 	DrainTimeout       time.Duration   `yaml:"drain_timeout"`
 
 	BoshResolverConfig *pcap.BoshResolverConfig `yaml:"bosh,omitempty" validate:"dive"`

--- a/src/pcap/test/integration/agent_api_client.go
+++ b/src/pcap/test/integration/agent_api_client.go
@@ -21,7 +21,7 @@ import (
 
 var apiClient pcap.APIClient
 
-var MaxConcurrentCaptures uint = 2
+var MaxConcurrentCaptures int32 = 2
 
 // port is used for creating agents.
 var port = 9494


### PR DESCRIPTION
Minor refactor. We compare maxConcurrentCaptures to concurrentStreams which should match datatypes.