### PR TITLE
feat: Add support for local development with TLS enabled.

### DIFF
--- a/.run/agent_local.run.xml
+++ b/.run/agent_local.run.xml
@@ -3,6 +3,7 @@
     <module name="pcap-release" />
     <target name="@@@LOCAL@@@" />
     <working_directory value="$PROJECT_DIR$/src/pcap" />
+    <parameters value="$PROJECT_DIR$/src/pcap/config/gen/agent-config.yml" />
     <sudo value="true" />
     <kind value="PACKAGE" />
     <package value="github.com/cloudfoundry/pcap-release/src/pcap/cmd/pcap-agent" />

--- a/.run/api_local.run.xml
+++ b/.run/api_local.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="api_local" type="GoApplicationRunConfiguration" factoryName="Go Application" folderName="local">
     <module name="pcap-release" />
     <target name="@@@LOCAL@@@" />
-    <working_directory value="$PROJECT_DIR$" />
+    <working_directory value="$PROJECT_DIR$/src/pcap" />
     <parameters value="$PROJECT_DIR$/src/pcap/config/gen/api-config.yml" />
     <kind value="PACKAGE" />
     <package value="github.com/cloudfoundry/pcap-release/src/pcap/cmd/pcap-api" />

--- a/.run/bosh-cli_local-tls.run.xml
+++ b/.run/bosh-cli_local-tls.run.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="bosh-cli_local" type="GoApplicationRunConfiguration" factoryName="Go Application" folderName="local">
+  <configuration default="false" name="bosh-cli_local-tls" type="GoApplicationRunConfiguration" factoryName="Go Application" folderName="local">
     <module name="pcap-release" />
     <target name="@@@LOCAL@@@" />
     <working_directory value="$PROJECT_DIR$/src/pcap" />
-    <parameters value="-d haproxy -g ha_proxy_z1 -o $PROJECT_DIR$/pcap-tcpdump.pcap -u http://localhost:8081 -c config/gen/bosh_config -i lo0 -e bosh -F" />
+    <parameters value="-d haproxy -g ha_proxy_z1 -o $PROJECT_DIR$/pcap-tcpdump.pcap -k -u https://localhost:8081 -c config/gen/bosh_config -i lo0 -e bosh -F -v" />
     <kind value="PACKAGE" />
     <package value="github.com/cloudfoundry/pcap-release/src/pcap/cmd/pcap-bosh-cli" />
     <directory value="$PROJECT_DIR$" />

--- a/.run/mock-bosh-setup-tls.run.xml
+++ b/.run/mock-bosh-setup-tls.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mock-bosh-setup-tls" type="GoApplicationRunConfiguration" factoryName="Go Application" folderName="local" activateToolWindowBeforeRun="false">
+    <module name="pcap-release" />
+    <working_directory value="$PROJECT_DIR$/src/pcap" />
+    <parameters value="-t" />
+    <kind value="PACKAGE" />
+    <package value="github.com/cloudfoundry/pcap-release/src/pcap/devtools/mock-bosh-setup" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/src/pcap/cmd/mock-bosh-api/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/pcap/client.go
+++ b/src/pcap/client.go
@@ -102,14 +102,16 @@ func (c *Client) Stop() {
 // ConnectToAPI sets up the grpc-connection between client and pcap-api.
 //
 // Depending on the http scheme in apiURL, it uses plain HTTP or TLS.
-func (c *Client) ConnectToAPI(apiURL *url.URL) error {
+func (c *Client) ConnectToAPI(apiURL *url.URL, skipVerify bool) error {
 	var (
 		err   error
 		creds credentials.TransportCredentials
 	)
 
 	if apiURL.Scheme == "https" {
-		creds = credentials.NewTLS(newTLSConfig())
+		tlsConfig := newTLSConfig()
+		tlsConfig.InsecureSkipVerify = skipVerify
+		creds = credentials.NewTLS(tlsConfig)
 	} else { // plain http
 		creds = insecure.NewCredentials()
 	}

--- a/src/pcap/cmd/pcap-bosh-cli/main.go
+++ b/src/pcap/cmd/pcap-bosh-cli/main.go
@@ -48,6 +48,7 @@ type options struct {
 	InstanceIds        []string `positional-arg-name:"ids" description:"The instance IDs of the deployment to capture." required:"false"`
 	SnapLength         uint16   `short:"l" long:"snaplen" description:"Snap Length, defining the captured length of the packet, with the remainder truncated. The real packet length is recorded." default:"65535"`
 	Verbose            bool     `short:"v" long:"verbose" description:"Show verbose debug information"`
+	Insecure           bool     `short:"k" long:"insecure" description:"Allow insecure server connections" required:"false"`
 	Quiet              bool     `short:"q" long:"quiet" description:"Show only warnings and errors"`
 }
 
@@ -121,7 +122,7 @@ func main() {
 		err = fmt.Errorf("could not set up pcap-client: %w", err)
 		return
 	}
-	err = client.ConnectToAPI(apiURL)
+	err = client.ConnectToAPI(apiURL, opts.Insecure)
 	if err != nil {
 		err = fmt.Errorf("could not connect to pcap-api: %w", err)
 		return

--- a/src/pcap/devtools/mock-bosh-setup/ca.go
+++ b/src/pcap/devtools/mock-bosh-setup/ca.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"os"
+	"time"
+)
+
+// Some helper tools to generate x509 CAs and Certificates
+
+const RootCABits = 4096
+const ServerCertBits = 2048
+const ClientCertBits = 2048
+const RootCASerial = 1337
+const ServerCertSerial = 3141
+const ClientCertSerial = 2718
+
+type CA struct {
+	Cert    *x509.Certificate
+	Key     *rsa.PrivateKey
+	CertPEM *bytes.Buffer
+	KeyPEM  *bytes.Buffer
+}
+
+type ClientCert struct {
+	Cert    *x509.Certificate
+	Key     *rsa.PrivateKey
+	CertPEM *bytes.Buffer
+	KeyPEM  *bytes.Buffer
+}
+
+type ServerCert struct {
+	Cert    *x509.Certificate
+	Key     *rsa.PrivateKey
+	CertPEM *bytes.Buffer
+	KeyPEM  *bytes.Buffer
+}
+
+// certPEM returns a given x509 certificate binary in PEM format.
+func certPEM(certBytes []byte) *bytes.Buffer {
+	certPEM := new(bytes.Buffer)
+	err := pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return certPEM
+}
+
+// keyPEM returns a given RSA private key in PEM format.
+func keyPEM(key *rsa.PrivateKey) *bytes.Buffer {
+	keyPEM := new(bytes.Buffer)
+	err := pem.Encode(keyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return keyPEM
+}
+
+// writePem writes a pem to disk.
+func writePem(filename string, pem *bytes.Buffer) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	_, _ = io.Copy(file, pem)
+	return nil
+}
+
+// newCA creates a new CA for testing purposes.
+func newCA(cn string) (*CA, error) {
+	ca := &CA{}
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(RootCASerial),
+		Subject: pkix.Name{
+			Organization:  []string{"Cloud Foundry"},
+			Country:       []string{"DE"},
+			Province:      []string{""},
+			Locality:      []string{"Walldorf"},
+			StreetAddress: []string{},
+			PostalCode:    []string{},
+			CommonName:    cn,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, RootCABits)
+	if err != nil {
+		return nil, err
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	caPEM := certPEM(caBytes)
+	caPrivKeyPEM := keyPEM(caPrivKey)
+
+	ca.Cert = cert
+	ca.Key = caPrivKey
+	ca.CertPEM = caPEM
+	ca.KeyPEM = caPrivKeyPEM
+
+	return ca, nil
+}
+
+// ClientCert issues a new client certificate signed by the given CA.
+func (ca *CA) ClientCert(cn string) (*ClientCert, error) {
+	clientCert := &ClientCert{}
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(ClientCertSerial),
+		Subject: pkix.Name{
+			Organization:  ca.Cert.Subject.Organization,
+			Country:       ca.Cert.Subject.Country,
+			Province:      ca.Cert.Subject.Province,
+			Locality:      ca.Cert.Subject.Locality,
+			StreetAddress: ca.Cert.Subject.StreetAddress,
+			PostalCode:    ca.Cert.Subject.PostalCode,
+			CommonName:    cn,
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(1, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, ClientCertBits)
+	if err != nil {
+		return nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca.Cert, &certPrivKey.PublicKey, ca.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM := certPEM(certBytes)
+	keyPEM := keyPEM(certPrivKey)
+
+	clientCert.CertPEM = certPEM
+	clientCert.KeyPEM = keyPEM
+	clientCert.Cert = cert
+	clientCert.Key = certPrivKey
+
+	return clientCert, nil
+}
+
+// ServerCert issues a new server certificate signed by the given CA.
+func (ca *CA) ServerCert(cn string) (*ServerCert, error) {
+	serverCert := &ServerCert{}
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(ServerCertSerial),
+		Subject: pkix.Name{
+			Organization:  ca.Cert.Subject.Organization,
+			Country:       ca.Cert.Subject.Country,
+			Province:      ca.Cert.Subject.Province,
+			Locality:      ca.Cert.Subject.Locality,
+			StreetAddress: ca.Cert.Subject.StreetAddress,
+			PostalCode:    ca.Cert.Subject.PostalCode,
+			CommonName:    cn,
+		},
+		DNSNames:     []string{cn},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(1, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, ServerCertBits)
+	if err != nil {
+		return nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca.Cert, &certPrivKey.PublicKey, ca.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM := certPEM(certBytes)
+	keyPEM := keyPEM(certPrivKey)
+
+	serverCert.CertPEM = certPEM
+	serverCert.KeyPEM = keyPEM
+	serverCert.Cert = cert
+	serverCert.Key = certPrivKey
+
+	return serverCert, nil
+}

--- a/src/pcap/test/integration/agent_api_client.go
+++ b/src/pcap/test/integration/agent_api_client.go
@@ -394,7 +394,7 @@ var _ = Describe("Using LocalResolver", func() {
 				Expect(err).To(BeNil())
 
 				apiURL := mock.MustParseURL(fmt.Sprintf("http://%s", apiAddr.String()))
-				err = client.ConnectToAPI(apiURL)
+				err = client.ConnectToAPI(apiURL, false)
 				Expect(err).To(BeNil())
 
 				ctx := context.Background()
@@ -418,7 +418,7 @@ var _ = Describe("Using LocalResolver", func() {
 
 				var stop time.Time
 				go func() {
-					time.Sleep(1 * time.Second)
+					time.Sleep(2 * time.Second)
 					GinkgoWriter.Println("sending Stop")
 					stop = time.Now().UTC()
 					client.StopRequest()

--- a/src/pcap/test/integration/bosh_resolver.go
+++ b/src/pcap/test/integration/bosh_resolver.go
@@ -100,7 +100,7 @@ var _ = Describe("Client to API with Bosh Resolver", func() {
 				client, err = pcap.NewClient("test.pcap", logger, messageWriter)
 				Expect(err).ShouldNot(HaveOccurred(), "failed initializing client")
 
-				err = client.ConnectToAPI(apiURL)
+				err = client.ConnectToAPI(apiURL, false)
 				Expect(err).ShouldNot(HaveOccurred(), "failed to connect to API")
 			})
 
@@ -248,7 +248,7 @@ var _ = Describe("Client to API with Bosh Resolver", func() {
 				client, err = pcap.NewClient("test.pcap", logger, messageWriter)
 				Expect(err).ShouldNot(HaveOccurred(), "failed initializing client")
 
-				err = client.ConnectToAPI(apiURL)
+				err = client.ConnectToAPI(apiURL, false)
 				Expect(err).ShouldNot(HaveOccurred(), "failed to connect to API")
 
 				// automatically stop capture after captureDuration
@@ -292,7 +292,7 @@ var _ = Describe("Client to API with Bosh Resolver", func() {
 				client, err = pcap.NewClient("test.pcap", logger, messageWriter)
 				Expect(err).ShouldNot(HaveOccurred(), "failed initializing client")
 
-				err = client.ConnectToAPI(apiURL)
+				err = client.ConnectToAPI(apiURL, false)
 				Expect(err).ShouldNot(HaveOccurred(), "failed to connect to API")
 
 				// automatically stop capture after captureDuration


### PR DESCRIPTION
This PR adds the option to run all pcap components locally with TLS enabled.
Two new run configurations:
- [.run/mock-bosh-setup-tls.run.xml](https://github.com/cloudfoundry/pcap-release/pull/106/files#diff-b166b6631b1403f4d0e7042b1632d97abb35b2c68d4f146461c19fc68fe7d805) This runs the mock BOSH director and generates pcap-api and pcap-agent configs with TLS enabled. It also generates all certificates needed.
- [.run/bosh-cli_local-tls.run.xml](https://github.com/cloudfoundry/pcap-release/pull/106/files#diff-3797f2305f617520682a8a80e3c8c7e697cd681748f4e128ae0b1aa3011b8dba) This starts the CLI with the `insecure` flag which is necessary because the pcap-api certificate is self-signed.

Also a `ca.go` file is added to take care of making certificates for the local TLS case. I felt like using step here would be overkill for just the local dev case. If we find we need to support more complex PKIs, using [step certificates](https://github.com/smallstep/certificates) may be viable.
