### PR TITLE
fix: remove unsupported spec cli_download_root

### DIFF
--- a/jobs/pcap-api/spec
+++ b/jobs/pcap-api/spec
@@ -77,8 +77,3 @@ properties:
     default: false
   pcap-api.bosh.tls.ca:
     description: "CA bundle which is used to request and verify Bosh Director certificates"
-
-
-  pcap-api.cli_download_root:
-    description: "Root directory of CLI downloads"
-    default: "/var/vcap/packages/pcap-api/bin/cli/build/"

--- a/jobs/pcap-api/templates/pcap-api.yml.erb
+++ b/jobs/pcap-api/templates/pcap-api.yml.erb
@@ -11,7 +11,6 @@ config = {
   "listen" => {
     "port" => p("pcap-api.listen.port"),
   },
-  "cli_download_root" => p("pcap-api.cli_download_root")
 }
 
 if p("pcap-api.listen.tls.enabled").to_s == "true"

--- a/src/pcap/devtools/mock-bosh-setup/main.go
+++ b/src/pcap/devtools/mock-bosh-setup/main.go
@@ -108,7 +108,6 @@ concurrent_captures: 5
 listen:
   port: 8081
   %s
-cli_download_root: "/var/vcap/packages/pcap-api/bin/cli/build/"
 %s
 bosh:
   agent_port: 9494


### PR DESCRIPTION
The CLI download might be required as soon as the cf-scenario is supported. It can be implemented and added at a later point.