### PR TITLE
test: disable flaky unit test

### DIFF
--- a/src/pcap/test/integration/agent_api_client.go
+++ b/src/pcap/test/integration/agent_api_client.go
@@ -384,7 +384,10 @@ var _ = Describe("Using LocalResolver", func() {
 			agentServer1.GracefulStop()
 			apiServer.GracefulStop()
 		})
-		Context("with client sending SIGINT after 5 seconds", func() {
+		// Mark test spec as pending
+		// This test is flaky and should be rework to be a part of a stable test suite
+		// In the test it is expected that packets are not empty, but sometimes it is the case.
+		PContext("with client sending SIGINT after 5 seconds", func() {
 			It("handles capture stop gracefully", func() {
 				file := "bosh_e2e_integration_test.pcap"
 				_ = os.Remove(file) // remove test-file


### PR DESCRIPTION
The sporadically failing test will be marked as pending: 
```
P [PENDING]
Using LocalResolver
  From client to agent
    with client sending SIGINT after 5 seconds
      handles capture stop gracefully

Ran 22 of 23 Specs in 105.114 seconds
SUCCESS! -- 22 Passed | 0 Failed | 1 Pending | 0 Skipped
```