### PR TITLE
ci: de-couple unit and acceptance tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -171,7 +171,7 @@ jobs:
     serial: true
     plan:
     - do:
-      - { get: git-pull-requests, trigger: true, version: every, passed: [ unit-tests-pr ] }
+      - { get: git-pull-requests, trigger: true, version: every }
       - { get: stemcell }
     - put: git-pull-requests
       params:


### PR DESCRIPTION
Concourse is not the best when it comes to PR validations. To reduce the amount of stuck builds and PRs this commit de-couples the two checks. This might result in more wasted builds on the acceptance tests which are expensive, but the current situation which requires manually triggering the checks is much worse.