### PR TITLE
ci: Add CFN-CI to CODEOWNERS

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,10 +11,10 @@ jobs:
     if: github.actor == 'dependabot[bot]' || github.actor == 'CFN-CI'
     steps:
       - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        uses: hmarr/auto-approve-action@v4
+        with:
+          review-message: "Auto approved automated PR"
+          github-token: ${{secrets.CFN_CI_PAT}}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --rebase "$PR_URL"
         env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cloudfoundry/wg-app-runtime-platform-networking-extensions-approvers
+* @cloudfoundry/wg-app-runtime-platform-networking-extensions-approvers @CFN-CI


### PR DESCRIPTION
We need an approval from CODEOWNER to get the PR merged. For automerge for dependency PRs we want to add CFN-CI to CODEOWNER