### PR TITLE
ci: Remove duplicate of CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @cloudfoundry/wg-app-runtime-platform-networking-extensions-approvers


### PR DESCRIPTION
There are two CODEOWNERS file. One in the `root` folder and another one in the `.github/`.
Remove the file in the .github to have the file on the same level as in haproxy-boshrelease. 