### PR TITLE
ci: use cfcommunity/github-pr-resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -335,10 +335,7 @@ resource_types:
   - name: pull-request
     type: docker-image
     source:
-      repository: cf-routing.common.repositories.cloud.sap/eirini-github-pr-resource
-      tag: latest
-      username: ((docker.username))
-      password: ((docker.password))
+      repository: cfcommunity/github-pr-resource
 
   - name: gcs
     type: docker-image


### PR DESCRIPTION
Instead of depending on custom image, use standard cf community github pr resource.
